### PR TITLE
Separate tests to be run separately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,4 +14,4 @@ jobs:
           cmd: lint # will run `yarn lint` command
       - uses: borales/actions-yarn@v2.0.0
         with:
-          cmd: test # will run `yarn test` command
+          cmd: unit_test # will run `yarn unit_test` command

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "nodemon src/server.js",
     "dev:debug": "nodemon --inspect src/server.js",
     "test": "jest",
+    "unit_test": "jest unit",
+    "integration_test": "jest integration",
     "lint": "eslint src/**"
   },
   "dependencies": {


### PR DESCRIPTION
**What:**
Creates new commands to run unit and integration tests separately

**Why:**
With this we will be able to better identify where the problems are, another reason is that the mongo configuration has not yet been made in github actions and therefore it is not possible to run the integration tests for now